### PR TITLE
Add global environment

### DIFF
--- a/cmd/teabox.conf
+++ b/cmd/teabox.conf
@@ -1,3 +1,7 @@
 # Where to find all modules
 content: /home/bo/work/teabox/example
 callback: /tmp/teabox.sock
+
+# Environment, which applies to all modules
+env:
+  PYTHONPATH: /usr/share/eco/lib/python

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -39,6 +39,10 @@ content: /path/to/the/tree/of/modules
 # Usually /tmp is the safest place. The socket is created only when module
 # is actually called, and is removed after module finished run.
 callback: /tmp/teabox.sock
+
+# Global environment, which will be re-exported with each module call.
+env:
+  PYTHONPATH: /opt/scary/dungeons
 ```
 
 This config also contains branding theme (colors) for the Teabox instance. But it is described

--- a/teaboxlib/teaconf.go
+++ b/teaboxlib/teaconf.go
@@ -25,6 +25,7 @@ type TeaConf struct {
 	contentPath        string
 	initConfPath       string
 	callbackSocketPath string
+	globalEnv          map[string]string
 
 	modIndex []TeaConfComponent
 	wzlib_logger.WzLogger
@@ -48,6 +49,13 @@ func NewTeaConf(appname string) (*TeaConf, error) {
 	tc.contentPath = cfg.Root().String("content", "")
 	tc.callbackSocketPath = cfg.Root().String("callback", "")
 	tc.initConfPath = path.Join(tc.contentPath, "init.conf")
+
+	environ, exists := cfg.Root().Raw()["env"]
+	if exists {
+		for envKey, envVar := range environ.(map[interface{}]interface{}) {
+			os.Setenv(fmt.Sprintf("%v", envKey), fmt.Sprintf("%v", envVar))
+		}
+	}
 
 	if err := tc.initConfig(); err != nil {
 		return nil, fmt.Errorf("unable to initialise modules: %s", err)


### PR DESCRIPTION
Allows to add global environment in a main configuration, such as:

```yaml
env:
  FOO: bar
  BAZ: fred
  PYTHONPATH: /opt/scary/dungeons
```

This environment will be exported to all external calls.