### PR TITLE
Fix alerting: redirect STDERR to an alert pop-up

### DIFF
--- a/teabox_app.go
+++ b/teabox_app.go
@@ -1,7 +1,11 @@
 package teabox
 
 import (
+	"fmt"
 	"io/ioutil"
+	"os"
+	"strings"
+	"time"
 
 	"github.com/davecgh/go-spew/spew"
 	"github.com/isbm/crtview"
@@ -60,4 +64,20 @@ func GetTeaboxQuitMessage() string {
 
 func DumpToFile(fn string, obj ...interface{}) {
 	ioutil.WriteFile(fn, []byte(spew.Sdump(obj...)), 0644)
+}
+
+func AddToFile(fn string, data string) error {
+	f, err := os.OpenFile(fn, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		return err
+	}
+
+	defer f.Close()
+	for _, chunk := range []string{"--------------", time.Now().Format("2006-01-02 15:04:05"), data} {
+		if _, err := f.WriteString(fmt.Sprintf("%v\n", strings.TrimSpace(chunk))); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }

--- a/teaboxlib/teaboxui/argsform.go
+++ b/teaboxlib/teaboxui/argsform.go
@@ -288,12 +288,14 @@ func (taf *TeaboxArgsForm) generateForms(c teaboxlib.TeaConfComponent) {
 				if err := formPanel.GetLandingPage().Action(modcmd.GetCommandPath(), f.GetCommandArguments(f.GetId())...); err != nil {
 					alert = taf.workspace.alertPopup
 					alert.SetTitle(fmt.Sprintf("%s: Module Error", mod.GetTitle()))
+					alert.SetTextAutofill(false)
 					alert.SetMessage(fmt.Sprintf("Error while calling\n%s\n%s", modcmd.GetCommandPath(), err.Error()))
 					panelPtr = "_alert-popup"
 
 				} else {
 					alert = taf.workspace.infoPopup
 					alert.SetTitle("Success!")
+					alert.SetTextAutofill(false)
 					alert.SetMessage(fmt.Sprintf("%s finished", mod.GetTitle()))
 				}
 				alert.SetOnConfirmAction(func() {

--- a/teaboxlib/teaboxui/teawidgets/lander_logger.go
+++ b/teaboxlib/teaboxui/teawidgets/lander_logger.go
@@ -98,10 +98,14 @@ func (tsw *TeaLoggerWindowLander) GetWindowAction() func(call *teaboxlib.TeaboxA
 func (tsw *TeaLoggerWindowLander) Action(cmdpath string, cmdargs ...string) error {
 	cmd := exec.Command(cmdpath, cmdargs...)
 	cmd.Stdout = tsw.GetWindow()
-	cmd.Stderr = tsw.GetWindow()
 
-	if err := cmd.Run(); err != nil {
-		return fmt.Errorf(fmt.Sprintf("Error: command \"%s %s\" quit as %s", cmdpath, strings.Join(cmdargs, " "), err.Error()))
+	buf := new(strings.Builder)
+	cmd.Stderr = buf
+
+	err := cmd.Run()
+	if err != nil {
+		teabox.AddToFile("eco-errors.log", fmt.Sprintf("Error: command \"%s %s\" quit as %s\nOutput: %s", cmdpath, strings.Join(cmdargs, " "), err.Error(), buf.String()))
+		return fmt.Errorf(buf.String())
 	}
 
 	return nil


### PR DESCRIPTION
When a module does not work right and fails, its output is shown in a red pop-up instead.