### PR TITLE
Add view-only field attribute

### DIFF
--- a/docs/writing_module_define.md
+++ b/docs/writing_module_define.md
@@ -239,8 +239,12 @@ implemented attributes:
 
 Common attributes:
 - `skip-empty`
-  Teabox **always** adds a given option to a target script by default. This attribute allows
-  to omit a named argument in the command line, if a value of it is not provided.
+  Omit empty named argument. Since teabox **always** adds a given option to a target script by default,
+  this attribute allows to omit a named argument in the command line, if no value given.
+
+- `view-only`
+  Teabox will **never** send this field as an option or a named argument. It turns any field only for
+  information purposes. For example, to show a table with existing repositories or users or user groups etc.
 
 Attributes for `tabular` widget only:
 - `selector`

--- a/teaboxlib/teaboxui/teawidgets/argsform_main.go
+++ b/teaboxlib/teaboxui/teawidgets/argsform_main.go
@@ -154,13 +154,20 @@ func (tmw *TeaboxArgsMainWindow) GetCommandArguments(formid string) []string {
 
 	// Get ordered arguments, if any
 	for _, arg := range tmw.argindex {
+		// Skip argument, it is for view-only
+		if tmw.namedArg[arg].GetAttrs().HasOption("view-only") {
+			continue
+		}
+
+		// Maybe skip argument, depending how on value conditions
 		val := tmw.argset[arg]
 		if val != "" {
 			val = fmt.Sprintf("%s=%s", arg, val)
-		} else if tmw.namedArg[arg].GetAttrs() != nil && !tmw.namedArg[arg].GetAttrs().HasOption("skip-empty") || tmw.namedArg[arg].GetAttrs() == nil {
+		} else if tmw.namedArg[arg].GetAttrs() == nil || !tmw.namedArg[arg].GetAttrs().HasOption("skip-empty") {
 			val = arg
 		}
 
+		// Add agreed argument
 		if val != "" {
 			cargs = append(cargs, val)
 		}

--- a/teaboxlib/teaconf_mod.go
+++ b/teaboxlib/teaconf_mod.go
@@ -194,6 +194,10 @@ func (a *TeaConfModArg) GetWidgetLabel() string {
 
 // GetAttrs returns argument extra attributes
 func (a *TeaConfModArg) GetAttrs() *TeaConfArgAttributes {
+	if a.attrs == nil {
+		return NewTeaConfArgAttributes(nil)
+	}
+
 	return a.attrs
 }
 


### PR DESCRIPTION
Introduce `view-only` field attribute for all fields. This allows Teabox define a widget and setup it for viewing purposes, but never sent it as a parameter to the target. Use-case, such as list existing users, groups, repos etc to just help fill-in the form.
