### PR TITLE
Add signal slots

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+.gitignore
+.vscode*
+cmd/teabox
+cmd/teabox.conf
+example/modules/hv/
+docs/_*
+.#*

--- a/cmd/teabox.go
+++ b/cmd/teabox.go
@@ -21,12 +21,12 @@ func main() {
 	appname := path.Base(os.Args[0])
 
 	conf, err := teaboxlib.NewTeaConf(appname)
-	defer os.Remove(conf.GetSocketPath())
-
 	if err != nil {
 		fmt.Printf("Error: %s\n", err.Error())
 		os.Exit(1)
 	}
+
+	defer os.Remove(conf.GetSocketPath())
 
 	app := teabox.GetTeaboxApp().SetGlobalConfig(conf)
 	app.SetRoot(teaboxui.InitTeaboxMainWindow().GetContent(), true)

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -12,6 +12,10 @@ BUILDDIR      = _build
 help:
 	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 
+setup:
+	sudo apt install pip gcc g++
+	pip install sphinx myst_parser karma-sphinx-theme
+
 .PHONY: help Makefile
 
 # Catch-all target: route all unknown targets to Sphinx using the new

--- a/docs/api_list.md
+++ b/docs/api_list.md
@@ -196,3 +196,40 @@ Clear value of a field by label. Example usage:
 Clear value of a field by order index. Example usage:
 
     field.reset.by-label::{0}
+
+## Session (State Storage)
+
+Session is a very simple key/value in-memory storage to maintain module state across scripts
+and share the information between them, if it is needed. Syntax is the same as key/value
+accessing fields.
+### `sesstion.set`
+
+Set a value to the session using a key. Example usage:
+
+    session.set::{name}"John Smith"
+    session.set:int:{age}42
+
+### `session.get`
+
+Get a value from the session, using a key. Example usage (keys are _always_ strings):
+
+    session.get::name
+    session.get::age
+
+### `session.keys`
+
+Get a list of available keys in the session. It returns a list of them. Example:
+
+    session.keys::
+
+### `session.delete`
+
+Delete a particular value by key from the session. Example (keys are _always_ strings):
+
+    session.delete::name
+
+### `session.flush`
+
+Flush the entire session, emptying it. Example:
+
+    session.flush::

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -22,6 +22,7 @@ Welcome to Teabox's documentation!
    writing_module_define
    writing_module_preload
    writing_module_lander
+   signal_slots
    rebranding
    api_overview
    api_list

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,0 @@
-myst_parser
-karma-sphinx-theme

--- a/docs/signal_slots.md
+++ b/docs/signal_slots.md
@@ -1,0 +1,67 @@
+# Writing Dynamic UI
+
+Often is the case that the UI is not just a form to collect data and that's all about it.
+In fact, we want sometimes hide/show some widgets, reset their values, validate their contents
+and these sort of things.
+
+Teabox offers a simple signalling mechanism. It more works like old-school Web CGI script.
+
+## Module State
+
+Your Bash *(or Python or [whatever](https://esolangs.org/wiki/Brainfuck))* script can have
+its state during the session. If you activated a form in Teabox, it will create a session
+for you, which essentially is a very simple in-memory key/value storage when Teabox is running.
+Typical use-cases for the session are:
+
+- Maintain module state
+- Exchange data between separate scripts
+- Exchange data between modules
+
+You can refer to the {doc}`api_list` description for details how to access it.
+
+### Data Visibility
+
+Each key is actually named with the prefix of the module name. If the name is "`my_module`",
+then a key e.g. "`foo`" in reality will be stored as "`my_module.foo`". So there is no way to
+access from the other module, because then request key will be prefixed with that module and so on.
+
+Therefore all keys are always private to a module.
+
+### Public Visibility
+
+However, if there is a need to share data across the modules *(not recommended due to "ad-hoc"
+nature of this approach)*, this is still possible to declare a key as public.
+
+To declare a key as public, it needs to be prefixed with a colon "`:`", like so:
+
+    session::set{:name}"John Smith"
+
+In this case key "`:name`" will not be prefixed and in this way can be accessed from anywhere,
+e.g. from another module within the same runtime session of Teabox.
+
+## Signal Slots
+
+Signal slots allows to perform an action when an event occurs. There are following events
+supported:
+- Widget was selected
+- Widget was de-selected
+- Widget was changed (its value)
+
+Each of these widget states can trigger an action that calls any script within the module 
+directory, where the parameters are defined in "`init.conf`" file of the module itself.
+
+Example:
+
+```yaml
+args:
+  - type: toggle
+    name: --
+    attributes:
+      - view-only
+    label: "Show other widget"
+    signals:
+      selected: target.sh --show-optional-widgets
+      deselected: target.sh --hide-optional-widgets
+```
+
+The script "`target.sh`" then should implement all the logic and call any of Teabox's {doc}`api_list` to do something, for example hide or show a widget, or fill it with some value etc.

--- a/example/modules/examples/passwordfield/init.conf
+++ b/example/modules/examples/passwordfield/init.conf
@@ -27,8 +27,11 @@ commands:
         label: "User ID"
         options:
           - ["Alice"]
+
       - type: masked
         name: --password
         label: "Password"
         options:
           - []
+        attributes:
+          - hidden

--- a/example/modules/examples/passwordfield/init.conf
+++ b/example/modules/examples/passwordfield/init.conf
@@ -7,6 +7,21 @@ commands:
   - path: psw.sh
     title: Print "Passwords"
     args:
+      - type: toggle
+        name: --bogus
+        attributes:
+          - view-only
+        label: "Use credentials"
+
+        # Aggregate "signals" calls an external commands
+        # according to the state of the widget
+        signals:
+          selected: psw.sh --do-something-when-checked
+          deselected: psw.sh --do-something-when-is-not-checked
+
+        options:
+          - [true]
+
       - type: text
         name: --name
         label: "User ID"

--- a/example/modules/examples/passwordfield/psw.sh
+++ b/example/modules/examples/passwordfield/psw.sh
@@ -20,6 +20,14 @@ else
 		setup
 		break
 		;;
+	    --do-something-when-checked)
+		date >> checked.txt
+		break
+		;;
+	    --do-something-when-is-not-checked)
+		date >> unchecked.txt
+		break
+		;;
             *)
 		run $@
 		break

--- a/example/modules/examples/passwordfield/psw.sh
+++ b/example/modules/examples/passwordfield/psw.sh
@@ -21,11 +21,10 @@ else
 		break
 		;;
 	    --do-something-when-checked)
-		date >> checked.txt
+		api session.set "{test}John Smith"
 		break
 		;;
 	    --do-something-when-is-not-checked)
-		date >> unchecked.txt
 		break
 		;;
             *)

--- a/teabox_app.go
+++ b/teabox_app.go
@@ -20,6 +20,7 @@ var __MSG_REF string
 type TeaboxApplication struct {
 	callback *teaboxlib.TeaboxSocketServer
 	config   *teaboxlib.TeaConf
+	session  *teaboxlib.TeaboxRuntimeSession
 
 	*crtview.Application
 }
@@ -33,6 +34,11 @@ func (ta *TeaboxApplication) GetCallbackServer() *teaboxlib.TeaboxSocketServer {
 func (ta *TeaboxApplication) SetGlobalConfig(conf *teaboxlib.TeaConf) *TeaboxApplication {
 	ta.config = conf
 	return ta
+}
+
+// GetSession instance
+func (ta *TeaboxApplication) GetSession() *teaboxlib.TeaboxRuntimeSession {
+	return ta.session
 }
 
 // GetGlobalConfig of the application
@@ -53,6 +59,7 @@ func GetTeaboxApp() *TeaboxApplication {
 		__APP_REF = &TeaboxApplication{
 			Application: crtview.NewApplication(),
 			callback:    teaboxlib.NewTeaboxSocketServer(),
+			session:     teaboxlib.NewTeaboxRuntimeSession(),
 		}
 	}
 	return __APP_REF

--- a/teaboxlib/runtime_session.go
+++ b/teaboxlib/runtime_session.go
@@ -1,0 +1,81 @@
+package teaboxlib
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+)
+
+// TeaboxRuntimeSession is a key/value storage per a module
+type TeaboxRuntimeSession struct {
+	kws map[string]interface{}
+	mtx sync.RWMutex
+}
+
+// NewTeaboxRuntimeSession constructor
+func NewTeaboxRuntimeSession() *TeaboxRuntimeSession {
+	rts := new(TeaboxRuntimeSession)
+	rts.kws = map[string]interface{}{}
+	rts.mtx = *new(sync.RWMutex)
+
+	return rts
+}
+
+// Set value to the session storage
+func (rts *TeaboxRuntimeSession) Set(modname, k string, v interface{}) {
+	rts.mtx.Lock()
+	defer rts.mtx.Unlock()
+
+	rts.kws[fmt.Sprintf("%s-%s", modname, k)] = v
+}
+
+// Get value from the session storage
+func (rts *TeaboxRuntimeSession) Get(modname, k string) interface{} {
+	rts.mtx.RLock()
+	defer rts.mtx.RUnlock()
+
+	v, ok := rts.kws[fmt.Sprintf("%s-%s", modname, k)]
+	if !ok {
+		return nil
+	}
+
+	return v
+}
+
+// Keys returns of all available keys of the session.
+// It includes also public keys, prefixed with ":" colon.
+func (rts *TeaboxRuntimeSession) Keys(modname string) []string {
+	rts.mtx.RLock()
+	defer rts.mtx.RUnlock()
+
+	keys := []string{}
+	for k := range rts.kws {
+		if strings.HasPrefix(k, modname+"-") || strings.HasPrefix(k, ":") {
+			keys = append(keys, k[len(modname):])
+		}
+	}
+
+	return keys
+}
+func (rts *TeaboxRuntimeSession) Delete(modname, k string) {
+	rts.mtx.Lock()
+	defer rts.mtx.Unlock()
+
+	delete(rts.kws, fmt.Sprintf("%s-%s", modname, k))
+}
+
+// Delete the entire session for the module. This does not affect
+// public keys and data from other modules.
+func (rts *TeaboxRuntimeSession) Flush(modname string) {
+	keys := rts.Keys(modname)
+
+	rts.mtx.Lock()
+	defer rts.mtx.Unlock()
+
+	for _, k := range keys {
+		if strings.HasPrefix(k, ":") {
+			continue
+		}
+		delete(rts.kws, k)
+	}
+}

--- a/teaboxlib/runtime_session.go
+++ b/teaboxlib/runtime_session.go
@@ -51,7 +51,10 @@ func (rts *TeaboxRuntimeSession) Keys(modname string) []string {
 	keys := []string{}
 	for k := range rts.kws {
 		if strings.HasPrefix(k, modname+"-") || strings.HasPrefix(k, ":") {
-			keys = append(keys, k[len(modname):])
+			k = k[len(modname)+1:]
+			if k != "" {
+				keys = append(keys, k)
+			}
 		}
 	}
 

--- a/teaboxlib/sig_call.go
+++ b/teaboxlib/sig_call.go
@@ -1,0 +1,43 @@
+package teaboxlib
+
+import (
+	"fmt"
+	"os/exec"
+	"path"
+)
+
+type SigCall struct {
+	modCmd *TeaConfModCommand
+}
+
+// NewSigCall creates
+func NewSigCall(mc *TeaConfModCommand) *SigCall {
+	sc := new(SigCall)
+	sc.modCmd = mc
+	return sc
+}
+
+// CallSignal action of the widget (any)
+func (sc *SigCall) CallSignal(act *TeaConfArgSignalAction) {
+	if err := sc.call(act); err != nil {
+		panic(fmt.Sprintf("Error while calling signal \"%s %v\": %s", act.GetName(), act.GetArguments(), err.Error()))
+	}
+}
+
+func (sc *SigCall) call(act *TeaConfArgSignalAction) error {
+	if sc.modCmd == nil {
+		return fmt.Errorf("error signal call: undefined module configuration")
+	}
+
+	if act.GetName() == "" { // Undefined call
+		return nil
+	}
+
+	pth := path.Dir(sc.modCmd.GetCommandPath())
+	out, err := exec.Command(path.Join(pth, act.GetName()), act.GetArguments()...).CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("error: %v\n%v", err.Error(), out)
+	}
+
+	return nil
+}

--- a/teaboxlib/teaboxui/argsform.go
+++ b/teaboxlib/teaboxui/argsform.go
@@ -76,7 +76,23 @@ func (tfp *TeaFormsPanel) AddPanel(name string, item crtview.Primitive, resize b
 // StartListener of Unix socket, and add handlers for it.
 func (tfp *TeaFormsPanel) StartListener() error {
 	tfp.landingPage.Reset()
-	teabox.GetTeaboxApp().GetCallbackServer().AddLocalAction(tfp.landingPage.GetWindowAction())
+	teabox.GetTeaboxApp().GetCallbackServer().
+		AddLocalAction(tfp.landingPage.GetWindowAction()).
+		AddLocalAction(func(c *teaboxlib.TeaboxAPICall) {
+			modId := path.Base(tfp.moduleConfig.GetModulePath())
+			switch c.GetClass() {
+			case "session.set":
+				teabox.GetTeaboxApp().GetSession().Set(modId, c.GetKey(), c.GetValue())
+			case "session.get":
+				// XXX: Implement getting data. This should be also writer not just listener in the socket
+			case "session.keys":
+				// XXX: Implement getting data. This should be also writer not just listener in the socket
+			case "session.delete":
+				teabox.GetTeaboxApp().GetSession().Delete(modId, c.GetString())
+			case "session.flush":
+				teabox.GetTeaboxApp().GetSession().Flush(modId)
+			}
+		})
 
 	// Run the Unix server instance
 	if err := teabox.GetTeaboxApp().GetCallbackServer().Start(tfp.moduleConfig.GetCallbackPath()); err != nil {

--- a/teaboxlib/teaboxui/argsform.go
+++ b/teaboxlib/teaboxui/argsform.go
@@ -84,9 +84,13 @@ func (tfp *TeaFormsPanel) StartListener() error {
 			case "session.set":
 				teabox.GetTeaboxApp().GetSession().Set(modId, c.GetKey(), c.GetValue())
 			case "session.get":
-				// XXX: Implement getting data. This should be also writer not just listener in the socket
+				r := teabox.GetTeaboxApp().GetSession().Get(modId, c.GetKey())
+				teabox.GetTeaboxApp().GetSession()
+				if r != nil {
+					return fmt.Sprintf("%v", r)
+				}
 			case "session.keys":
-				// XXX: Implement getting data. This should be also writer not just listener in the socket
+				return strings.Join(teabox.GetTeaboxApp().GetSession().Keys(modId), ",")
 			case "session.delete":
 				teabox.GetTeaboxApp().GetSession().Delete(modId, c.GetString())
 			case "session.flush":

--- a/teaboxlib/teaboxui/argsform.go
+++ b/teaboxlib/teaboxui/argsform.go
@@ -56,8 +56,8 @@ func (tfp *TeaFormsPanel) GetLandingPage() teawidgets.TeaboxLandingWindow {
 }
 
 // GetFormsSocketListerActions returns all actions from all forms
-func (tfp *TeaFormsPanel) GetFormsSocketListenerActions() []func(*teaboxlib.TeaboxAPICall) {
-	actions := []func(*teaboxlib.TeaboxAPICall){}
+func (tfp *TeaFormsPanel) GetFormsSocketListenerActions() []func(*teaboxlib.TeaboxAPICall) string {
+	actions := []func(*teaboxlib.TeaboxAPICall) string{}
 	for _, ref := range tfp.objref {
 		form, ok := ref.(*teawidgets.TeaboxArgsMainWindow)
 		if !ok {
@@ -78,7 +78,7 @@ func (tfp *TeaFormsPanel) StartListener() error {
 	tfp.landingPage.Reset()
 	teabox.GetTeaboxApp().GetCallbackServer().
 		AddLocalAction(tfp.landingPage.GetWindowAction()).
-		AddLocalAction(func(c *teaboxlib.TeaboxAPICall) {
+		AddLocalAction(func(c *teaboxlib.TeaboxAPICall) string {
 			modId := path.Base(tfp.moduleConfig.GetModulePath())
 			switch c.GetClass() {
 			case "session.set":
@@ -92,6 +92,8 @@ func (tfp *TeaFormsPanel) StartListener() error {
 			case "session.flush":
 				teabox.GetTeaboxApp().GetSession().Flush(modId)
 			}
+
+			return ""
 		})
 
 	// Run the Unix server instance

--- a/teaboxlib/teaboxui/teawidgets/argsform_loading.go
+++ b/teaboxlib/teaboxui/teawidgets/argsform_loading.go
@@ -119,10 +119,10 @@ func (ld *TeaboxArgsLoadingWindow) Reset() {
 }
 
 // GetSocketAcceptAction is a function for Unix socket on action
-func (ld *TeaboxArgsLoadingWindow) GetSocketAcceptAction() func(*teaboxlib.TeaboxAPICall) {
-	return func(call *teaboxlib.TeaboxAPICall) {
+func (ld *TeaboxArgsLoadingWindow) GetSocketAcceptAction() func(*teaboxlib.TeaboxAPICall) string {
+	return func(call *teaboxlib.TeaboxAPICall) string {
 		if !ld.IsVisible() {
-			return // Don't update here anything, we are invisible
+			return "" // Don't update here anything, we are invisible
 		}
 		switch call.GetClass() {
 		case teaboxlib.INIT_SET_PROGRESS:
@@ -138,6 +138,7 @@ func (ld *TeaboxArgsLoadingWindow) GetSocketAcceptAction() func(*teaboxlib.Teabo
 		}
 
 		teabox.GetTeaboxApp().Draw()
+		return ""
 	}
 }
 

--- a/teaboxlib/teaboxui/teawidgets/argsform_main.go
+++ b/teaboxlib/teaboxui/teawidgets/argsform_main.go
@@ -411,7 +411,7 @@ func (tmw *TeaboxArgsMainWindow) updateField(call *teaboxlib.TeaboxAPICall, item
 
 	case *crtview.CheckBox:
 		if op != __OP_W_CLR {
-			field.SetChecked(call.GetBool())
+			field.SetChecked(call.GetBool()) // This does NOT triggers onChange hook!
 			if call.GetBool() {
 				tmw.AddArgument(tmw.GetId(), arg.GetArgName(), arg.GetOptions()[0].GetLabel())
 			} else {

--- a/teaboxlib/teaboxui/teawidgets/argsform_main.go
+++ b/teaboxlib/teaboxui/teawidgets/argsform_main.go
@@ -341,8 +341,8 @@ func (tmw *TeaboxArgsMainWindow) AddCheckBox(arg *teaboxlib.TeaConfModArg) error
 	return nil
 }
 
-func (tmw *TeaboxArgsMainWindow) GetSocketAcceptAction() func(*teaboxlib.TeaboxAPICall) {
-	return func(call *teaboxlib.TeaboxAPICall) {
+func (tmw *TeaboxArgsMainWindow) GetSocketAcceptAction() func(*teaboxlib.TeaboxAPICall) string {
+	return func(call *teaboxlib.TeaboxAPICall) string {
 		switch call.GetClass() {
 
 		// Overwriting with the new values
@@ -369,6 +369,7 @@ func (tmw *TeaboxArgsMainWindow) GetSocketAcceptAction() func(*teaboxlib.TeaboxA
 		case teaboxlib.FORM_CLR_TABLE_BY_ORD:
 			tmw.updateField(call, tmw.GetFormItem(call.GetKeyAsInt()), __OP_W_SET)
 		}
+		return ""
 	}
 }
 

--- a/teaboxlib/teaboxui/teawidgets/lander_logger.go
+++ b/teaboxlib/teaboxui/teawidgets/lander_logger.go
@@ -17,7 +17,7 @@ It is used to show the output of a called script.
 */
 
 type TeaLoggerWindowLander struct {
-	action    func(call *teaboxlib.TeaboxAPICall)
+	action    func(call *teaboxlib.TeaboxAPICall) string
 	statusBar *crtview.TextView
 	titleBar  *crtview.TextView
 	w         *crtview.TextView
@@ -60,7 +60,7 @@ func NewTeaLoggerWindowLander() *TeaLoggerWindowLander {
 	c.AddItem(c.statusBar, 1, 0, false)
 
 	// Action definition
-	c.action = func(call *teaboxlib.TeaboxAPICall) {
+	c.action = func(call *teaboxlib.TeaboxAPICall) string {
 		switch call.GetClass() {
 		case teaboxlib.LOGGER_STATUS:
 			c.statusBar.SetText(call.GetString())
@@ -68,6 +68,7 @@ func NewTeaLoggerWindowLander() *TeaLoggerWindowLander {
 			c.titleBar.SetText(call.GetString())
 		}
 		teabox.GetTeaboxApp().Draw()
+		return ""
 	}
 
 	c.Reset()
@@ -91,7 +92,7 @@ func (tsw *TeaLoggerWindowLander) GetWindow() *crtview.TextView {
 	return tsw.w
 }
 
-func (tsw *TeaLoggerWindowLander) GetWindowAction() func(call *teaboxlib.TeaboxAPICall) {
+func (tsw *TeaLoggerWindowLander) GetWindowAction() func(call *teaboxlib.TeaboxAPICall) string {
 	return tsw.action
 }
 

--- a/teaboxlib/teaboxui/teawidgets/lander_progress.go
+++ b/teaboxlib/teaboxui/teawidgets/lander_progress.go
@@ -139,7 +139,7 @@ type TeaProgressWindowLander struct {
 	lookupRegex  string
 
 	checklist   *landerChecklist
-	action      func(call *teaboxlib.TeaboxAPICall)
+	action      func(call *teaboxlib.TeaboxAPICall) string
 	title       *crtview.TextView    // Title of the lander page
 	eventBar    *crtview.TextView    // Like a status bar, but shows a chunk of the progress
 	generalInfo *crtview.TextView    // General text information (static per module)
@@ -222,7 +222,7 @@ func (pl *TeaProgressWindowLander) init() *TeaProgressWindowLander {
 	//pl.AddItem(spacer, 4, 1, false)
 
 	// Define API receiver
-	pl.action = func(call *teaboxlib.TeaboxAPICall) {
+	pl.action = func(call *teaboxlib.TeaboxAPICall) string {
 		switch call.GetClass() {
 		case teaboxlib.COMMON_PROGRESS_EVENT:
 			pl.eventBar.SetText(call.GetString())
@@ -263,6 +263,7 @@ func (pl *TeaProgressWindowLander) init() *TeaProgressWindowLander {
 		}
 
 		teabox.GetTeaboxApp().Draw()
+		return ""
 	}
 
 	return pl
@@ -310,7 +311,7 @@ func (pl *TeaProgressWindowLander) AsWidgetPrimitive() crtview.Primitive {
 
 // Return window receiver action on Unix socket calls, specific per this widget.
 // This action is called by Unix socket among others, and it picks up stuff that are needed.
-func (pl *TeaProgressWindowLander) GetWindowAction() func(call *teaboxlib.TeaboxAPICall) {
+func (pl *TeaProgressWindowLander) GetWindowAction() func(call *teaboxlib.TeaboxAPICall) string {
 	return pl.action
 }
 

--- a/teaboxlib/teaboxui/teawidgets/wgt_itf.go
+++ b/teaboxlib/teaboxui/teawidgets/wgt_itf.go
@@ -28,7 +28,7 @@ type TeaboxLandingWindow interface {
 	StopListener() error
 
 	// Return window action on Unix socket calls, specific per this widget
-	GetWindowAction() func(call *teaboxlib.TeaboxAPICall)
+	GetWindowAction() func(call *teaboxlib.TeaboxAPICall) string
 
 	// Reset all the values to the initial state
 	Reset()

--- a/teaboxlib/teaconf.go
+++ b/teaboxlib/teaconf.go
@@ -63,6 +63,11 @@ func NewTeaConf(appname string) (*TeaConf, error) {
 	return tc, nil
 }
 
+// GetContentPath returns root path to all modules
+func (tc *TeaConf) GetContentPath() string {
+	return tc.contentPath
+}
+
 func (tc *TeaConf) GetTitle() string {
 	return tc.title
 }

--- a/teaboxlib/teaconf_mod.go
+++ b/teaboxlib/teaconf_mod.go
@@ -125,6 +125,9 @@ type TeaConfModArg struct {
 	// Attributes of the argument
 	attrs *TeaConfArgAttributes
 
+	// Signals of the widget
+	signals *TeaConfArgSignals
+
 	// Preset options. They can be also loaded dynamically via socket
 	options []*TeaConfCmdOption
 
@@ -151,6 +154,19 @@ func NewTeaConfModArg(args map[interface{}]interface{}) *TeaConfModArg {
 		case "attributes":
 			attrs, _ := wd.([]interface{}) // Avoid explicit cast crash. If syntax is wrong, then just skip it by passing nil.
 			a.attrs = NewTeaConfArgAttributes(attrs)
+		case "signals":
+			sigs, ok := wd.(map[interface{}]interface{})
+			if !ok {
+				a.GetLogger().Error("signals should be key/value syntax")
+				a.GetLogger().Debug(spew.Sdump(wd))
+				os.Exit(1)
+			} else {
+				var err error
+				a.signals, err = NewTeaConfArgSignals(sigs)
+				if err != nil {
+					a.GetLogger().Error(err.Error())
+				}
+			}
 		}
 	}
 
@@ -199,6 +215,15 @@ func (a *TeaConfModArg) GetAttrs() *TeaConfArgAttributes {
 	}
 
 	return a.attrs
+}
+
+func (a *TeaConfModArg) GetSignals() *TeaConfArgSignals {
+	if a.signals == nil {
+		sigs, _ := NewTeaConfArgSignals(nil)
+		return sigs
+	}
+
+	return a.signals
 }
 
 func (a *TeaConfModArg) GetOptions() []*TeaConfCmdOption {

--- a/teaboxlib/teaconf_sig.go
+++ b/teaboxlib/teaconf_sig.go
@@ -1,0 +1,116 @@
+package teaboxlib
+
+import (
+	"fmt"
+	"strings"
+)
+
+type TeaConfArgSignalAction struct {
+	name string
+	args []string
+}
+
+// Signal action takes raw string and parses it into an action with the whole verfication
+func NewTeaConfArgSignalAction(action string) (*TeaConfArgSignalAction, error) {
+	act := new(TeaConfArgSignalAction)
+	act.args = []string{}
+
+	if action == "" {
+		return act, nil
+	}
+
+	err := act.parse(action)
+	if err != nil {
+		return nil, err
+	}
+
+	return act, nil
+}
+
+// GetName of the command to be called
+func (act *TeaConfArgSignalAction) GetName() string {
+	return act.name
+}
+
+// GetArguments of the command
+func (act *TeaConfArgSignalAction) GetArguments() []string {
+	return act.args
+}
+
+// Parse the signal action
+func (act *TeaConfArgSignalAction) parse(action string) error {
+	cmd := []string{}
+	for _, c := range strings.Split(action, " ") {
+		c = strings.TrimSpace(c)
+		if c != "" {
+			cmd = append(cmd, c)
+		}
+	}
+	if len(cmd) < 1 {
+		return fmt.Errorf("could not parse signal action")
+	}
+
+	act.name = cmd[0]
+	if len(cmd) > 1 {
+		act.args = cmd[1:]
+	}
+
+	return nil
+}
+
+// TeaConfArgSignals is a container of all signals, defined per a widget argument
+type TeaConfArgSignals struct {
+	sigs map[string]*TeaConfArgSignalAction
+}
+
+// NewTeaConfArgSignlans constructor
+func NewTeaConfArgSignals(data map[interface{}]interface{}) (*TeaConfArgSignals, error) {
+	tcsig := new(TeaConfArgSignals)
+	tcsig.sigs = map[string]*TeaConfArgSignalAction{}
+
+	if data == nil {
+		data = map[interface{}]interface{}{}
+	}
+
+	for k, v := range data {
+		action, err := NewTeaConfArgSignalAction(fmt.Sprintf("%v", v))
+		if err != nil {
+			return nil, err
+		} else {
+			tcsig.SetSignal(fmt.Sprintf("%v", k), action)
+		}
+	}
+
+	return tcsig, nil
+}
+
+// GetSignals defined to the specific widget of an argument
+func (tcsig *TeaConfArgSignals) GetSignals() []string {
+	sigs := []string{}
+	for sigdef := range tcsig.sigs {
+		sigs = append(sigs, sigdef)
+	}
+
+	return sigs
+}
+
+// GetSignalValue returns a defined command on a specific signal
+func (tcsig *TeaConfArgSignals) GetSignalValue(sigdef string) *TeaConfArgSignalAction {
+	sig, ok := tcsig.sigs[sigdef]
+	if !ok {
+		dummy, _ := NewTeaConfArgSignalAction("")
+		return dummy
+	}
+
+	return sig
+}
+
+// SetSignal sets a signal to a slot. If such signal previously set, the new will be ignored.
+func (tcsig *TeaConfArgSignals) SetSignal(sigdef string, value *TeaConfArgSignalAction) *TeaConfArgSignals {
+	_, ok := tcsig.sigs[sigdef]
+	if !ok { // set only when key does not exist yet
+		tcsig.sigs[sigdef] = value
+	}
+
+	return tcsig
+}


### PR DESCRIPTION
Allow define signal slots, similar to QT or GTK, when a click on a widget or any other event on it can trigger defined action. This particular PR allows call scripts with arguments that would implement functional logic to control/react within the UI.

Example usage:

```yaml
- type: toggle
  signals:
    selected: somescript.sh --some-flag --some=value --and-so=on
    deselected: someotherscript.sh --some-other-flag
```

That said, `somescript.sh` will be triggered when a toggle is selected, and thus it then can call API to the Teabox and perform various actions, such as hide/show widgets, preset them with the values etc or do any other possible functions.

NOTE: Since redraw is synchronous with the call return, your script should be relatively fast enough that the selection of the widget is not taking long.

Additionally, it adds session handling. Each signal can also set its state into a runtime session and retrieve the data on the next trigger call.