### PR TITLE
Bugfix: UI muted if target stript has no exec attr

### DIFF
--- a/teaboxlib/teaboxui/argsform.go
+++ b/teaboxlib/teaboxui/argsform.go
@@ -2,6 +2,7 @@ package teaboxui
 
 import (
 	"fmt"
+	"os"
 	"path"
 	"strings"
 
@@ -235,6 +236,14 @@ func (taf *TeaboxArgsForm) ShowModuleForm(id string) {
 				cmd = path.Join(formsPanel.GetModuleConfig().GetModulePath(), formsPanel.GetModuleConfig().GetSetupCommand())
 			} else {
 				cmd = formsPanel.GetModuleConfig().GetSetupCommand()
+			}
+
+			// Skip load if the loader path is not exectuable.
+			// This is a module problem and can be caused by various reasons: bad packaging, misaligned deployment etc
+			statfo, err := os.Stat(cmd)
+			if (err != nil) || (statfo.Mode()&0111 == 0) {
+				loader.SkipLoad()
+				return
 			}
 
 			// Skip loader if conditions are not met

--- a/teaboxlib/teaconf_mod.go
+++ b/teaboxlib/teaconf_mod.go
@@ -268,6 +268,10 @@ func (tmc *TeaConfModCommand) parse(cmd map[interface{}]interface{}) *TeaConfMod
 			switch sk {
 			case "path":
 				tmc.path = sv
+				if tmc.path == "" {
+					failed = "No target executable defined"
+					break
+				}
 			case "title":
 				tmc.title = sv
 			case "option":


### PR DESCRIPTION
If any module has target script set no `+x` mode, then UI will just disappear, showing bare terminal and hang until `^C` applied.
